### PR TITLE
Float fix and CONSOLE name

### DIFF
--- a/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
+++ b/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
@@ -41,8 +41,8 @@ public class BanknotePlugin extends JavaPlugin {
     /*
      * REGEX to find money
      */
-    private final Pattern MONEY_PATTERN = Pattern.compile("([+-]?[0-9]{1,3}(?:,?[0-9]{3})(?:\\.)?[0-9]{0,2})");
-
+    //Original Regex just in case: ([+-]?[0-9]{1,3}(?:,?[0-9]{3})(?:\.)?[0-9]{0,2})
+    private final Pattern MONEY_PATTERN = Pattern.compile("((([1-9]\\d{0,2}(,\\d{3})*)|(([1-9]\\d*)?\\d))(\\.?\\d?\\d?)?$)");
     @Override
     public void onEnable() {
         // Save configuration and register listeners
@@ -194,6 +194,8 @@ public class BanknotePlugin extends JavaPlugin {
                     if (matcher.find()) {
                         String amount = matcher.group(1);
                         return Double.parseDouble(amount.replaceAll(",", ""));
+
+
                     }
                 }
             }

--- a/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
+++ b/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
@@ -41,7 +41,7 @@ public class BanknotePlugin extends JavaPlugin {
     /*
      * REGEX to find money
      */
-    private final Pattern MONEY_PATTERN = Pattern.compile("([+-]?[0-9]{1,3}(?:,?[0-9]{3})*\\.[0-9]{2})");
+    private final Pattern MONEY_PATTERN = Pattern.compile("([+-]?[0-9]{1,3}(?:,?[0-9]{3})(?:\\.)?[0-9]{0,2})");
 
     @Override
     public void onEnable() {
@@ -90,8 +90,12 @@ public class BanknotePlugin extends JavaPlugin {
      */
     public String formatDouble(double value) {
         NumberFormat nf = NumberFormat.getInstance(Locale.ENGLISH);
-        nf.setMaximumFractionDigits(2);
-        nf.setMinimumFractionDigits(2);
+
+        int max = getConfig().getInt("settings.maximum-float-amount");
+        int min = getConfig().getInt("settings.minimum-float-amount");
+
+        nf.setMaximumFractionDigits(max);
+        nf.setMinimumFractionDigits(min);
         return nf.format(value);
     }
 

--- a/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
+++ b/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
@@ -142,10 +142,9 @@ public class BanknotePlugin extends JavaPlugin {
         // Format the base lore
         for (String baseLore : this.baseLore) {
 
-            if (creatorName == "CONSOLE") {
+            if (creatorName.equals("CONSOLE")) {
                 creatorName = getConfig().getString("settings.console-name");
             }
-
             formatLore.add(colorMessage(baseLore.replace("[money]", formatDouble(amount)).replace("[player]", creatorName)));
         }
 

--- a/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
+++ b/src/main/java/com/sainttx/banknotes/BanknotePlugin.java
@@ -141,6 +141,11 @@ public class BanknotePlugin extends JavaPlugin {
 
         // Format the base lore
         for (String baseLore : this.baseLore) {
+
+            if (creatorName == "CONSOLE") {
+                creatorName = getConfig().getString("settings.console-name");
+            }
+
             formatLore.add(colorMessage(baseLore.replace("[money]", formatDouble(amount)).replace("[player]", creatorName)));
         }
 

--- a/src/main/java/com/sainttx/banknotes/command/BanknotesCommand.java
+++ b/src/main/java/com/sainttx/banknotes/command/BanknotesCommand.java
@@ -62,7 +62,7 @@ public class BanknotesCommand implements CommandExecutor {
                     sender.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.invalid-number")));
                 } else {
                     ItemStack banknote = plugin.createBanknote(sender.getName(), amount);
-
+                    target.getInventory().addItem(banknote);
 
                     //Use console-name if the note is given by a console command
                     String senderName = sender instanceof ConsoleCommandSender ? plugin.getConfig().getString("settings.console-name") : sender.getName();

--- a/src/main/java/com/sainttx/banknotes/command/BanknotesCommand.java
+++ b/src/main/java/com/sainttx/banknotes/command/BanknotesCommand.java
@@ -62,11 +62,26 @@ public class BanknotesCommand implements CommandExecutor {
                     sender.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.invalid-number")));
                 } else {
                     ItemStack banknote = plugin.createBanknote(sender.getName(), amount);
-                    
+
+
+                    //Use console-name if the note is given by a console command
+                    String senderName = sender instanceof ConsoleCommandSender ? plugin.getConfig().getString("settings.console-name") : sender.getName();
+                    target.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-received")
+                            .replace("[money]", plugin.formatDouble(amount))
+                            .replace("[player]", senderName)));
+                    sender.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-given")
+                            .replace("[money]", plugin.formatDouble(amount))
+                            .replace("[player]", target.getName())));
+
+
+        /*
+
+                    //Old code, just in case.
+
                     if (sender instanceof ConsoleCommandSender) {
                         String senderName = plugin.getConfig().getString("settings.console-name");
-
                         target.getInventory().addItem(banknote);
+
                         target.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-received")
                                 .replace("[money]", plugin.formatDouble(amount))
                                 .replace("[player]", senderName)));
@@ -83,6 +98,9 @@ public class BanknotesCommand implements CommandExecutor {
                                 .replace("[money]", plugin.formatDouble(amount))
                                 .replace("[player]", target.getName())));
                     }
+
+        */
+
                 }
             }
             return true;

--- a/src/main/java/com/sainttx/banknotes/command/BanknotesCommand.java
+++ b/src/main/java/com/sainttx/banknotes/command/BanknotesCommand.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -61,13 +62,27 @@ public class BanknotesCommand implements CommandExecutor {
                     sender.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.invalid-number")));
                 } else {
                     ItemStack banknote = plugin.createBanknote(sender.getName(), amount);
-                    target.getInventory().addItem(banknote);
-                    target.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-received")
-                            .replace("[money]", plugin.formatDouble(amount))
-                            .replace("[player]", sender.getName())));
-                    sender.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-given")
-                            .replace("[money]", plugin.formatDouble(amount))
-                            .replace("[player]", target.getName())));
+                    
+                    if (sender instanceof ConsoleCommandSender) {
+                        String senderName = plugin.getConfig().getString("settings.console-name");
+
+                        target.getInventory().addItem(banknote);
+                        target.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-received")
+                                .replace("[money]", plugin.formatDouble(amount))
+                                .replace("[player]", senderName)));
+                        sender.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-given")
+                                .replace("[money]", plugin.formatDouble(amount))
+                                .replace("[player]", target.getName())));
+                    }else if (sender instanceof Player) {
+
+                        target.getInventory().addItem(banknote);
+                        target.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-received")
+                                .replace("[money]", plugin.formatDouble(amount))
+                                .replace("[player]", sender.getName())));
+                        sender.sendMessage(plugin.colorMessage(plugin.getConfig().getString("messages.note-given")
+                                .replace("[money]", plugin.formatDouble(amount))
+                                .replace("[player]", target.getName())));
+                    }
                 }
             }
             return true;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,6 +26,9 @@ messages:
   target-not-found: "Couldn't find a player with that name"
   
 settings:
+  console-name: "&7Server"
+  minimum-float-amount: 0
+  maximum-float-amount: 2
   minimum-withdraw-amount: 10.0
   maximum-withdraw-amount: 5000.0
   allow-right-click-to-deposit-notes: true


### PR DESCRIPTION
Added to config:

```
console-name
minimum-float-amount
maximum-float-amount
```

console-name allows the user to specify a name to be used in place of CONSOLE if the console gives a banknote to the player.

minimum-float-amount and maximum-float-amount allows the user to specify what they'd like the float of the money amount to be, i.e. 0 ($1,000), 1, ($1,000.1), or 2 ($1,000.11). This cleans up the note, removing unneeded digits from the money amount.

Hope this helps out, and sorry for the previous push. Still getting used to IntelliJ. :)
