### PR TITLE
Updated VaultAPI from 1.5 to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
         </repository>
 
         <repository>
-            <id>vault-repo</id>
-            <url>http://nexus.theyeticave.net/content/repositories/pub_releases</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -62,9 +62,9 @@
         </dependency>
 
         <dependency>
-            <groupId>net.milkbowl.vault</groupId>
+            <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
-            <version>1.5</version>
+            <version>1.7</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updated as "How to include the API with Maven:" instructions found at: https://github.com/MilkBowl/VaultAPI